### PR TITLE
Add instrument toggle and tuning UI

### DIFF
--- a/Tuni/ContentView.swift
+++ b/Tuni/ContentView.swift
@@ -4,18 +4,41 @@ import AVFoundation
 struct ContentView: View {
     @StateObject private var audioManager = AudioManager()
     @Environment(\.scenePhase) private var scenePhase
+    @State private var instrument: Instrument = .guitar
 
     var body: some View {
         VStack(spacing: 20) {
-            Button("Start Tuning") {
-                audioManager.start()
+            Picker("Instrument", selection: $instrument) {
+                ForEach(Instrument.allCases) { ins in
+                    Text(ins.rawValue.capitalized)
+                }
             }
-            .padding()
+            .pickerStyle(.segmented)
 
-            Button("Stop") {
-                audioManager.stop()
+            if audioManager.isRunning {
+                Image(systemName: "mic.fill")
+                    .foregroundColor(.red)
+
+                Button("Stop Tuning") {
+                    audioManager.stop()
+                }
+                .padding()
+
+                if let freq = audioManager.frequency {
+                    Text(String(format: "Detected %.2f Hz", freq))
+                } else {
+                    Text("Detecting…")
+                }
+
+                ForEach(instrument.strings.sorted(by: { $0.key < $1.key }), id: \.key) { note, target in
+                    TuningSlider(note: note, target: target, detected: audioManager.frequency)
+                }
+            } else {
+                Button("Start Tuning") {
+                    audioManager.start()
+                }
+                .padding()
             }
-            .padding()
         }
         .onChange(of: scenePhase) { phase in
             if phase != .active {

--- a/Tuni/Instrument.swift
+++ b/Tuni/Instrument.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum Instrument: String, CaseIterable, Identifiable {
+    case guitar
+    case bass
+
+    var id: String { rawValue }
+
+    var strings: [String: Double] {
+        switch self {
+        case .guitar:
+            return [
+                "E2": 82.41,
+                "A2": 110.0,
+                "D3": 146.83,
+                "G3": 196.0,
+                "B3": 246.94,
+                "E4": 329.63
+            ]
+        case .bass:
+            return [
+                "E1": 41.20,
+                "A1": 55.0,
+                "D2": 73.42,
+                "G2": 98.0
+            ]
+        }
+    }
+}

--- a/Tuni/TuningSlider.swift
+++ b/Tuni/TuningSlider.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct TuningSlider: View {
+    let note: String
+    let target: Double
+    let detected: Double?
+
+    private var range: ClosedRange<Double> {
+        let lower = max(0, target * 0.65)
+        return lower...target
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("\(note) - target \(String(format: "%.2f Hz", target))")
+                .font(.caption)
+            Slider(value: .constant(detected ?? target), in: range)
+                .disabled(true)
+            if let detected {
+                Text(String(format: "Detected %.2f Hz", detected))
+                    .font(.caption2)
+            }
+        }
+    }
+}
+
+#Preview {
+    TuningSlider(note: "E1", target: 41.2, detected: 38.0)
+}


### PR DESCRIPTION
## Summary
- expand `AudioManager` to publish mic status and frequency
- add `Instrument` model for guitar and bass string targets
- create `TuningSlider` view to show tuning progress
- update `ContentView` with instrument picker, mic indicator and tuning sliders

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_683e4044a474832aa81a5adf64d78dd9