### PR TITLE
Add ordered tuning flow

### DIFF
--- a/Tuni/ContentView.swift
+++ b/Tuni/ContentView.swift
@@ -6,6 +6,8 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     // Start with no instrument selected so the user must choose
     @State private var instrument: Instrument?
+    @State private var currentStringIndex = 0
+    @State private var tunedStrings: Set<Int> = []
 
     var body: some View {
         VStack(spacing: 20) {
@@ -33,14 +35,23 @@ struct ContentView: View {
                 }
 
                 if let instrument {
-                    ForEach(instrument.strings.sorted(by: { $0.key < $1.key }), id: \.key) { note, target in
-                        TuningSlider(note: note, target: target, detected: audioManager.frequency)
+                    ForEach(instrument.strings.indices, id: \.self) { index in
+                        let string = instrument.strings[index]
+                        TuningSlider(
+                            note: string.note,
+                            target: string.target,
+                            detected: index == currentStringIndex ? audioManager.frequency : nil,
+                            isCurrent: index == currentStringIndex,
+                            isTuned: tunedStrings.contains(index)
+                        )
                     }
                 }
             } else {
                 if instrument != nil {
                     Button("Start Tuning") {
                         audioManager.start()
+                        currentStringIndex = 0
+                        tunedStrings = []
                     }
                     .padding()
                 }
@@ -49,6 +60,20 @@ struct ContentView: View {
         .onChange(of: scenePhase) { phase in
             if phase != .active {
                 audioManager.stop()
+            }
+        }
+        .onChange(of: instrument) { _ in
+            currentStringIndex = 0
+            tunedStrings = []
+        }
+        .onChange(of: audioManager.frequency) { freq in
+            guard let instrument, let freq else { return }
+            let target = instrument.strings[currentStringIndex].target
+            if abs(freq - target) <= 2 && !tunedStrings.contains(currentStringIndex) {
+                tunedStrings.insert(currentStringIndex)
+                if currentStringIndex < instrument.strings.count - 1 {
+                    currentStringIndex += 1
+                }
             }
         }
     }

--- a/Tuni/Instrument.swift
+++ b/Tuni/Instrument.swift
@@ -6,23 +6,25 @@ enum Instrument: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var strings: [String: Double] {
+    /// Returns the instrument strings in the order they should be tuned
+    /// from lowest to highest pitch.
+    var strings: [(note: String, target: Double)] {
         switch self {
         case .guitar:
             return [
-                "E2": 82.41,
-                "A2": 110.0,
-                "D3": 146.83,
-                "G3": 196.0,
-                "B3": 246.94,
-                "E4": 329.63
+                ("E2", 82.41),
+                ("A2", 110.0),
+                ("D3", 146.83),
+                ("G3", 196.0),
+                ("B3", 246.94),
+                ("E4", 329.63)
             ]
         case .bass:
             return [
-                "E1": 41.20,
-                "A1": 55.0,
-                "D2": 73.42,
-                "G2": 98.0
+                ("E1", 41.20),
+                ("A1", 55.0),
+                ("D2", 73.42),
+                ("G2", 98.0)
             ]
         }
     }

--- a/Tuni/TuningSlider.swift
+++ b/Tuni/TuningSlider.swift
@@ -4,6 +4,8 @@ struct TuningSlider: View {
     let note: String
     let target: Double
     let detected: Double?
+    let isCurrent: Bool
+    let isTuned: Bool
 
     private var range: ClosedRange<Double> {
         let lower = max(0, target * 0.65)
@@ -12,8 +14,17 @@ struct TuningSlider: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text("\(note) - target \(String(format: "%.2f Hz", target))")
-                .font(.caption)
+            HStack {
+                if isCurrent {
+                    Image(systemName: "arrowtriangle.right.fill")
+                }
+                Text("\(note) - target \(String(format: "%.2f Hz", target))")
+                    .font(.caption)
+                if isTuned {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.green)
+                }
+            }
             Slider(value: .constant(detected ?? target), in: range)
                 .disabled(true)
             if let detected {
@@ -25,5 +36,5 @@ struct TuningSlider: View {
 }
 
 #Preview {
-    TuningSlider(note: "E1", target: 41.2, detected: 38.0)
+    TuningSlider(note: "E1", target: 41.2, detected: 38.0, isCurrent: true, isTuned: false)
 }


### PR DESCRIPTION
## Summary
- order strings for each instrument
- highlight current string and mark tuned strings
- move to next string automatically when within 2 Hz

## Testing
- `swiftc -frontend -parse Tuni/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_683e45659ea8832ab3ff6d48c8f82162