### PR TITLE
Improve pitch detection robustness

### DIFF
--- a/Tuni/ContentView.swift
+++ b/Tuni/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
 
                 Button("Stop Tuning") {
                     audioManager.stop()
+                    audioManager.setTargetFrequency(nil)
                 }
                 .padding()
 
@@ -50,6 +51,9 @@ struct ContentView: View {
                 if instrument != nil {
                     Button("Start Tuning") {
                         audioManager.start()
+                        if let instrument {
+                            audioManager.setTargetFrequency(instrument.strings[currentStringIndex].target)
+                        }
                         currentStringIndex = 0
                         tunedStrings = []
                     }
@@ -65,6 +69,11 @@ struct ContentView: View {
         .onChange(of: instrument) { _ in
             currentStringIndex = 0
             tunedStrings = []
+            if let instrument {
+                audioManager.setTargetFrequency(instrument.strings[currentStringIndex].target)
+            } else {
+                audioManager.setTargetFrequency(nil)
+            }
         }
         .onChange(of: audioManager.frequency) { freq in
             guard let instrument, let freq else { return }
@@ -73,6 +82,7 @@ struct ContentView: View {
                 tunedStrings.insert(currentStringIndex)
                 if currentStringIndex < instrument.strings.count - 1 {
                     currentStringIndex += 1
+                    audioManager.setTargetFrequency(instrument.strings[currentStringIndex].target)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- minimize noise influence in `AudioManager` by adding RMS gating and
  narrowing the search range around the selected string
- expose `setTargetFrequency` so `ContentView` can hint the detector
- update `ContentView` to pass target frequency when tuning starts, when
  changing strings or instruments, and when tuning stops

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683e4756a700832ab00c671b0afd8a9e