### PR TITLE
Improve tuner accuracy and UX

### DIFF
--- a/Tuni/ContentView.swift
+++ b/Tuni/ContentView.swift
@@ -8,9 +8,27 @@ struct ContentView: View {
     @State private var instrument: Instrument?
     @State private var currentStringIndex = 0
     @State private var tunedStrings: Set<Int> = []
+    /// When the frequency first entered the tolerance range.
+    @State private var stableStart: Date?
+
+    private let tolerance: Double = 2
+    private let requiredStability: TimeInterval = 0.5
 
     var body: some View {
         VStack(spacing: 20) {
+            if audioManager.isRunning {
+                if let freq = audioManager.frequency {
+                    Text(String(format: "Detected %.2f Hz", freq))
+                        .font(.headline)
+                } else {
+                    Text("Detecting…")
+                        .font(.headline)
+                }
+            } else {
+                Text("Not running")
+                    .font(.headline)
+            }
+
             Picker("Instrument", selection: $instrument) {
                 ForEach(Instrument.allCases) { ins in
                     Text(ins.rawValue.capitalized)
@@ -28,12 +46,6 @@ struct ContentView: View {
                     audioManager.setTargetFrequency(nil)
                 }
                 .padding()
-
-                if let freq = audioManager.frequency {
-                    Text(String(format: "Detected %.2f Hz", freq))
-                } else {
-                    Text("Detecting…")
-                }
 
                 if let instrument {
                     ForEach(instrument.strings.indices, id: \.self) { index in
@@ -76,14 +88,31 @@ struct ContentView: View {
             }
         }
         .onChange(of: audioManager.frequency) { freq in
-            guard let instrument, let freq else { return }
+            guard let instrument, let freq else {
+                stableStart = nil
+                return
+            }
+
             let target = instrument.strings[currentStringIndex].target
-            if abs(freq - target) <= 2 && !tunedStrings.contains(currentStringIndex) {
-                tunedStrings.insert(currentStringIndex)
-                if currentStringIndex < instrument.strings.count - 1 {
-                    currentStringIndex += 1
-                    audioManager.setTargetFrequency(instrument.strings[currentStringIndex].target)
+
+            if abs(freq - target) <= tolerance {
+                if stableStart == nil {
+                    stableStart = Date()
                 }
+
+                if let start = stableStart,
+                   Date().timeIntervalSince(start) >= requiredStability,
+                   !tunedStrings.contains(currentStringIndex) {
+                    tunedStrings.insert(currentStringIndex)
+                    stableStart = nil
+
+                    if currentStringIndex < instrument.strings.count - 1 {
+                        currentStringIndex += 1
+                        audioManager.setTargetFrequency(instrument.strings[currentStringIndex].target)
+                    }
+                }
+            } else {
+                stableStart = nil
             }
         }
     }

--- a/Tuni/TuningSlider.swift
+++ b/Tuni/TuningSlider.swift
@@ -8,8 +8,18 @@ struct TuningSlider: View {
     let isTuned: Bool
 
     private var range: ClosedRange<Double> {
-        let lower = max(0, target * 0.65)
-        return lower...target
+        let span = target * 0.3
+        let lower = max(1, target - span)
+        let upper = target + span
+        return lower...upper
+    }
+
+    private var tint: Color {
+        guard let detected else { return .gray }
+        let diff = abs(detected - target)
+        if diff < 1 { return .green }
+        if diff < 5 { return .yellow }
+        return .red
     }
 
     var body: some View {
@@ -27,6 +37,16 @@ struct TuningSlider: View {
             }
             Slider(value: .constant(detected ?? target), in: range)
                 .disabled(true)
+                .tint(tint)
+                .overlay(
+                    GeometryReader { geo in
+                        let width = geo.size.width
+                        Rectangle()
+                            .fill(Color.green.opacity(0.3))
+                            .frame(width: 4)
+                            .position(x: width / 2, y: geo.size.height / 2)
+                    }
+                )
             if let detected {
                 Text(String(format: "Detected %.2f Hz", detected))
                     .font(.caption2)


### PR DESCRIPTION
## Summary
- add live frequency readout at the top of the UI
- only advance to the next string after the pitch stays within range for 0.5s
- highlight the in‑tune zone on each slider and color by closeness

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_683eed1c3c88832a9b91a928d54e65ce